### PR TITLE
Should be error message instead of debug

### DIFF
--- a/src/types/json.rs
+++ b/src/types/json.rs
@@ -188,7 +188,7 @@ where
             .limit(limit)
             .map(move |res| match res {
                 Err(e) => {
-                    log::debug!(
+                    log::error!(
                         "Failed to deserialize Json from payload. \
                          Request path: {}",
                         req2.path()


### PR DESCRIPTION
Json from_request error message should be logged as error instead of debug